### PR TITLE
Do not encode subject for SES mail wrapper

### DIFF
--- a/src/Wrapper/AmazonSesWrapper.php
+++ b/src/Wrapper/AmazonSesWrapper.php
@@ -2,12 +2,26 @@
 
 namespace ByJG\Mail\Wrapper;
 
+use ByJG\Mail\Override\PHPMailerOverride;
 use Aws\Credentials\Credentials;
 use Aws\Ses\SesClient;
 use ByJG\Mail\Envelope;
 
 class AmazonSesWrapper extends PHPMailerWrapper
 {
+
+    /**
+     * @param Envelope $envelope
+     * @return PHPMailerOverride
+     * @throws \phpmailerException
+     */
+    protected function prepareMailer(Envelope $envelope)
+    {
+        $mail = parent::prepareMailer($envelope);
+        $mail->Subject = $envelope->getSubject();
+        return $mail;
+    }
+
     /**
      * @return SesClient
      */


### PR DESCRIPTION
Message subject is by default ISO encoded (in PHPMailerWrapper) but AWS SES accepts UTF-8 so there is no need to encode it.

When encoded the subject provided by AWS SES is not readable in e-mail client.