### PR TITLE
Mailgun region API selection based on region parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "phpmailer/phpmailer": "^6.0.3"
   },
   "require-dev": {
-    "phpunit/phpunit": ">5.7"
+    "phpunit/phpunit": "5.7.*|7.4.*"
   },
   "license": "MIT"
 }

--- a/src/Wrapper/MailgunApiWrapper.php
+++ b/src/Wrapper/MailgunApiWrapper.php
@@ -11,13 +11,20 @@ use ByJG\Util\WebRequest;
 
 class MailgunApiWrapper extends PHPMailerWrapper
 {
+
+    private $regions = [
+        'us' => 'api.mailgun.net',
+        'eu' => 'api.eu.mailgun.net',
+    ];
+
     /**
      * @return \ByJG\Util\WebRequest
      */
     public function getRequestObject()
     {
         $domainName = $this->uri->getHost();
-        $request = new WebRequest("https://api.mailgun.net/v3/$domainName/messages");
+        $apiUri = $this->getApiUri();
+        $request = new WebRequest("https://$apiUri/v3/$domainName/messages");
         $request->setCredentials('api', $this->uri->getUsername());
 
         return $request;
@@ -78,4 +85,15 @@ class MailgunApiWrapper extends PHPMailerWrapper
 
         return true;
     }
+
+    private function getApiUri()
+    {
+        $query = $this->uri->getQueryPart('region');
+        if (isset($this->regions[$query])) {
+            return $this->regions[$query];
+        }
+
+        return $this->regions['us'];
+    }
+
 }


### PR DESCRIPTION
Added support for EU Mailgun region (https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions)

- US (global) API is kept as default
- Region can be configured by query parameter "region" (example: mailgun://api-key@mg.domain.cz?region=eu)
- List of API endpoints is kept in MailgunApiWrapper
