### PR TITLE
Downgrade PHPMailer because it is causing some issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "byjg/uri": "1.0.*",
     "byjg/webrequest": "1.0.*",
     "aws/aws-sdk-php": "~3.20",
-    "phpmailer/phpmailer": "^6.0.3"
+    "phpmailer/phpmailer": "6.1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "5.7.*|7.4.*"


### PR DESCRIPTION
The PHPMailer is causing some issues with its recent upgrades and failing the unit tests. Probably that is the root cause of the issue #11 . 

The solution is downgrade and fix the PHPMailer version. 
